### PR TITLE
Upgrade to jammy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:rolling
+FROM ubuntu:jammy
 
 WORKDIR /source
 RUN apt-get update \


### PR DESCRIPTION
Upgrade to libabigail 2.0 from Ubuntu Jammy (to become 22.04 LTS / the next LTS)